### PR TITLE
Ignore feature

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -230,3 +230,9 @@ minetest.register_chatcommand("ignore", {
 		return false,"Player "..param.." not online. "..print_ignores(name)
 	end,
 })
+
+minetest.register_chatcommand("ignorestats", {
+	description = "Show who you ignore and who ignores you.",
+	privs = {shout = true},
+	func = function(name) return true,print_ignores(name) end,
+})

--- a/init.lua
+++ b/init.lua
@@ -132,7 +132,7 @@ local function process_msg(name,message,bycmd,recv)
 			send_all_ignore(name,message) 
 		end
 	else
-		minetest.chat_send_player(name,message)
+		send_ply_ignore(name,message,name)
 	end
 	return true
 end

--- a/init.lua
+++ b/init.lua
@@ -194,7 +194,7 @@ local function get_ignorers(name)
 	for p,l in pairs(clam_antispam.ignore) do
 		for pp,st in pairs(l) do
 			if name == pp then
-				table.insert(r,pp)
+				table.insert(r,p)
 			end
 		end
 	end

--- a/init.lua
+++ b/init.lua
@@ -58,11 +58,12 @@ msg_cap = {
 	[9]=10
 }--]]
 local function process_msg(name,message)
+	if badges and badges.get_badge(name) then return end
 	if msg_count[name] == nil then msg_count[name] = 0 end
 	if msg_count[name] <= 1 then first_msg[name] = os.time() end
 	local et=os.time() - first_msg[name] --elapsed time
 	msg_count[name] = msg_count[name] + 1
-	
+		
 	--restart the "loop" when the time hits the largest value from the list	
 	if et > msg_cap[#msg_cap] then 
 		msg_count[name] = 1

--- a/init.lua
+++ b/init.lua
@@ -70,8 +70,16 @@ local function send_all_ignore(name,msg)
 	end
 end
 
-local function process_msg(name,message)
-	--if badges and badges.get_badge(name) then return end
+local function process_msg(name,message,bycmd)
+	
+	if badges and badges.get_badge(name) then 
+		if bycmd then
+			return minetest.chat_send_all(message)
+		end
+		return badges.chat_send(name, message)
+	end
+	
+	
 	if msg_count[name] == nil then msg_count[name] = 0 end
 	if msg_count[name] <= 1 then first_msg[name] = os.time() end
 	local et=os.time() - first_msg[name] --elapsed time
@@ -123,7 +131,7 @@ minetest.register_chatcommand("me", {
 		if param:find("<") or param:find(">") then
 			param = minetest.strip_colors(param)
 		end
-		return process_msg(name," " .. minetest.colorize("#B0B0B0", name .. " " .. param))
+		return process_msg(name," " .. minetest.colorize("#B0B0B0", name .. " " .. param),true)
 	end,
 })
 
@@ -132,7 +140,7 @@ minetest.register_chatcommand("greentext", {
 	description = "Sends a message in greentext",
 	privs = {shout = true},
 	func = function(name, param)
-		return process_msg(name,minetest.colorize("#789922", " <" .. name .. ">: >" .. param))
+		return process_msg(name,minetest.colorize("#789922", " <" .. name .. ">: >" .. param),true)
 	end,
 })
 --table.insert(minetest.registered_on_chat_message, 1, 

--- a/init.lua
+++ b/init.lua
@@ -183,7 +183,7 @@ minetest.register_chatcommand("msg", {
 })
 
 minetest.register_on_chat_message(function(name, message)
-	return process_msg(name,'<'..name..'> '..message)
+	return process_msg(name,'<'..name..'>: '..message)
 end)
 
 minetest.register_on_leaveplayer(function(lp, timed_out) 

--- a/init.lua
+++ b/init.lua
@@ -185,7 +185,6 @@ local function get_ignores(name)
 	local r={}
 	for k,v in pairs(clam_antispam.ignore[name]) do
 		if v then table.insert(r,k) end
-		minetest.chat_send_all(k)
 	end
 	return r
 end

--- a/init.lua
+++ b/init.lua
@@ -181,7 +181,7 @@ minetest.register_chatcommand("msg", {
 		return true, "DM to "..sendto..": "..message
 	end,
 })
---table.insert(minetest.registered_on_chat_message, 1, 
+
 minetest.register_on_chat_message(function(name, message)
 	return process_msg(name,'<'..name..'> '..message)
 end)

--- a/mod.conf
+++ b/mod.conf
@@ -1,2 +1,3 @@
 name = clam_antispam
 description = Anti Chat spam for clamity anarchy
+optional_depends = badges


### PR DESCRIPTION
This adds the chatcommands /ignore <player>, /unignore <player> and /ignorestats.

Testing:
Confirm that ignoring and unignoring works properly with 2 instances.
Confirm that /ignorstats shows all ignorees and ignorers correctly.